### PR TITLE
simplify TargetFramework matching

### DIFF
--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -16,8 +16,8 @@ Target "Clean" (fun _ ->
 
     !! srcGlob
     ++ testsGlob
-    |> Seq.collect(fun p -> 
-        ["bin";"obj"] 
+    |> Seq.collect(fun p ->
+        ["bin";"obj"]
         |> Seq.map(fun sp ->
              IO.Path.GetDirectoryName p @@ sp)
         )
@@ -34,7 +34,7 @@ Target "DotnetRestore" (fun _ ->
                 Project = proj
                 //This makes sure that Proj2 references the correct version of Proj1
                 AdditionalArgs = [sprintf "/p:PackageVersion=%s" release.NugetVersion]
-            }) 
+            })
 ))
 
 Target "DotnetBuild" (fun _ ->
@@ -45,7 +45,7 @@ Target "DotnetBuild" (fun _ ->
                 Project = proj
                 //This makes sure that Proj2 references the correct version of Proj1
                 AdditionalArgs = [sprintf "/p:PackageVersion=%s" release.NugetVersion]
-            }) 
+            })
 ))
 
 let invoke f = f ()
@@ -55,13 +55,13 @@ type TargetFramework =
 | Full of string
 | Core of string
 
+let (|StartsWith|_|) prefix (s: string) =
+    if s.StartsWith prefix then Some () else None
+
 let getTargetFramework tf =
     match tf with
-    | "net45" | "net451" | "net452" 
-    | "net46" | "net461" | "net462" -> 
-        Full tf
-    | "netcoreapp1.0" | "netcoreapp1.1" -> 
-        Core tf
+    | StartsWith "net4" -> Full tf
+    | StartsWith "netcoreapp" -> Core tf
     | _ -> failwithf "Unknown TargetFramework %s" tf
 
 let getTargetFrameworksFromProjectFile (projFile : string)=
@@ -72,13 +72,13 @@ let getTargetFrameworksFromProjectFile (projFile : string)=
     |> Seq.toList
 
 let selectRunnerForFramework tf =
-    let runMono = sprintf "mono -f %s --restore -c Release" 
+    let runMono = sprintf "mono -f %s --restore -c Release"
     let runCore = sprintf "run -f %s -c Release"
     match tf with
     | Full t when isMono-> runMono t
     | Full t -> runCore t
     | Core t -> runCore t
-        
+
 
 let runTests modifyArgs =
     !! testsGlob
@@ -100,7 +100,7 @@ Target "DotnetTest" (fun _ ->
 )
 let execProcAndReturnMessages filename args =
     let args' = args |> String.concat " "
-    ProcessHelper.ExecProcessAndReturnMessages 
+    ProcessHelper.ExecProcessAndReturnMessages
                 (fun psi ->
                     psi.FileName <- filename
                     psi.Arguments <-args'
@@ -136,18 +136,18 @@ Target "DotnetPack" (fun _ ->
                 Project = proj
                 Configuration = "Release"
                 OutputPath = IO.Directory.GetCurrentDirectory() @@ "dist"
-                AdditionalArgs = 
+                AdditionalArgs =
                     [
                         sprintf "/p:PackageVersion=%s" release.NugetVersion
                         sprintf "/p:PackageReleaseNotes=\"%s\"" (String.Join("\n",release.Notes))
                     ]
-            }) 
+            })
     )
 )
 
 Target "Publish" (fun _ ->
     Paket.Push(fun c ->
-            { c with 
+            { c with
                 PublishUrl = "https://www.nuget.org"
                 WorkingDir = "dist"
             }


### PR DESCRIPTION
Hi,

this is a fix for "Unknown TargetFramework netcoreapp2.0" bug.
Other way would be to add each new released framework like "net47" and "netcoreapp2.0".
But is it not too much overhead to just select one of two runners? What do you think?