### PR TITLE
Fixed template packager

### DIFF
--- a/MiniScaffold.csproj
+++ b/MiniScaffold.csproj
@@ -11,7 +11,8 @@
 
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Content/**/*" Exclude="Content/packages/**/*;Content/.fake/**;Content/bin/**/**/*;Content/dist/*;Content/temp/*;Content/**/bin/**/**/*;Content/**/obj/**/**/*" >

--- a/MiniScaffold.csproj
+++ b/MiniScaffold.csproj
@@ -12,7 +12,7 @@
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Content/**/*" Exclude="Content/packages/**/*;Content/.fake/**;Content/bin/**/**/*;Content/dist/*;Content/temp/*;Content/**/bin/**/**/*;Content/**/obj/**/**/*" >


### PR DESCRIPTION
Appveyor now has dotnet core 2.0 on it which requires the target framework to be specified in csproj file. Travis has 1.1 installed.

This pull request is an attempt to get the build pipeline working again so future pull requests will work.