### PR TITLE
make output type switchable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Describe the big picture of your changes here to communicate to the maintainers 
 
 ## Types of changes
 
-What types of changes does your code introduce to Appium?
+What types of changes does your code introduce to MiniScaffold?
 _Put an `x` in the boxes that apply_
 
 - [ ] Bugfix (non-breaking change which fixes an issue)

--- a/Content/.github/PULL_REQUEST_TEMPLATE.md
+++ b/Content/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Describe the big picture of your changes here to communicate to the maintainers 
 
 ## Types of changes
 
-What types of changes does your code introduce to Appium?
+What types of changes does your code introduce to MyLib?
 _Put an `x` in the boxes that apply_
 
 - [ ] Bugfix (non-breaking change which fixes an issue)

--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/template",
   "author": "Jimmy Byrd",
   "classifications": [ "Scaffold" ],
   "name": "MiniScaffold",
@@ -14,6 +15,17 @@
       "githubUsername": {
           "type": "parameter",
           "replaces":"MyGithubUsername"
+      },
+      "outputType": {
+          "type": "parameter",
+          "datatype": "choice",
+          "choices": [
+              "Exe",
+              "Lib"
+          ],
+          "defaultValue": "Lib",
+          "description": "Is this project an executable or a library",
+          "replaces": "MyOutputType"
       }
   },
   "postActions": [{

--- a/Content/src/MyLib/MyLib.fsproj
+++ b/Content/src/MyLib/MyLib.fsproj
@@ -14,6 +14,7 @@
     <RepositoryType>git</RepositoryType>
     <Authors>MyUsername</Authors>
     <RepositoryUrl>https://github.com/MyGithubUsername/MyLib</RepositoryUrl>
+    <OutputType>MyOutputType</OutputType>
     <!-- owners is not supported in MSBuild -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ paket config add-token "https://www.nuget.org" 4003d786-cc37-4004-bfdf-c4f3e8ef9
 ./build.sh Release
 ```
 
+## Options
+
+### githubUserName
+
+This is uesd to atomatically configure author information in the nuget package, as well as configure push urls for repo locations.
+
+### outputType
+
+Defaults to `Lib`
+
+When set to either `Exe` or `Lib`, this sets the `OutputType` property of the generated `fsproj` file, so that you don't have to.
 
 ## Known issues
 


### PR DESCRIPTION
## Proposed Changes

F# slack has expressed a desire to make an executable from this template. 

## Types of changes

What types of changes does your code introduce to MiniScaffold?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

I would _love_ to test this but I can't figure out how to uninstall a previous version of the template.
Also the build script seems to be building the inner Content folder, which with this change is no longer buildable, because the output type `MyOutputType` isn't valid.  I didn't see a good way to keep that a buildable value but not accidentally find-and-replace a billion instances of `Lib` in the project.
