### PR TITLE
fix for values left unset in the fsproj file

### DIFF
--- a/Content/src/MyLib.1/MyLib.1.fsproj
+++ b/Content/src/MyLib.1/MyLib.1.fsproj
@@ -10,7 +10,7 @@
     <!-- summary is not migrated from project.json, but you can use the <Description> property for that if needed. -->
     <PackageTags>f#, fsharp</PackageTags>
     <PackageProjectUrl>https://github.com/MyGithubUsername/MyLib.1</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/MyGithubUsername/MyLib/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/MyGithubUsername/MyLib.1/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <Authors>MyUsername</Authors>

--- a/Content/src/MyLib.1/MyLib.1.fsproj
+++ b/Content/src/MyLib.1/MyLib.1.fsproj
@@ -13,7 +13,7 @@
     <PackageLicenseUrl>https://github.com/MyGithubUsername/MyLib.1/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
-    <Authors>MyUsername</Authors>
+    <Authors>MyGithubUsername</Authors>
     <RepositoryUrl>https://github.com/MyGithubUsername/MyLib.1</RepositoryUrl>
     <!-- owners is not supported in MSBuild -->
   </PropertyGroup>


### PR DESCRIPTION
## Proposed Changes

Fix for two values in the .fsproj file, `PackageLicenseUrl` and `Authors`, not being set properly.

## Types of changes

What types of changes does your code introduce to MiniScaffold?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
