### PR TITLE
do dotnet pack via sln

### DIFF
--- a/Content/Library/build.fsx
+++ b/Content/Library/build.fsx
@@ -242,23 +242,21 @@ Target.create "AssemblyInfo" <| fun _ ->
 
 
 Target.create "DotnetPack" <| fun ctx ->
-    !! srcGlob
-    |> Seq.iter (fun proj ->
-        let args =
-            [
-                sprintf "/p:PackageVersion=%s" release.NugetVersion
-                sprintf "/p:PackageReleaseNotes=\"%s\"" (release.Notes |> String.concat "\n")
-                sprintf "/p:SourceLinkCreate=%b" (isRelease (ctx.Context.AllExecutingTargets))
-            ] |> String.concat " "
-        DotNet.pack (fun c ->
-            { c with
-                Configuration = configuration (ctx.Context.AllExecutingTargets)
-                OutputPath = Some distDir
-                Common =
-                    c.Common
-                    |> DotNet.Options.withCustomParams (Some args)
-            }) proj
-    )
+    let args =
+        [
+            sprintf "/p:PackageVersion=%s" release.NugetVersion
+            sprintf "/p:PackageReleaseNotes=\"%s\"" (release.Notes |> String.concat "\n")
+            sprintf "/p:SourceLinkCreate=%b" (isRelease (ctx.Context.AllExecutingTargets))
+        ] |> String.concat " "
+    DotNet.pack (fun c ->
+        { c with
+            Configuration = configuration (ctx.Context.AllExecutingTargets)
+            OutputPath = Some distDir
+            Common =
+                c.Common
+                |> DotNet.Options.withCustomParams (Some args)
+        }) sln
+
 
 
 Target.create "SourcelinkTest" <| fun _ ->

--- a/Content/Library/src/Directory.Build.props
+++ b/Content/Library/src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
+</Project>

--- a/Content/Library/tests/Directory.Build.props
+++ b/Content/Library/tests/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Proposed Changes

This make it so dotnet pack runs on the sln file.  It adds `IsPackable` with true to `Directory.Build.props` in src and false in tests. 

## Types of changes

What types of changes does your code introduce to MiniScaffold?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
