### PR TITLE
Speed up DotnetRestore target

### DIFF
--- a/Content/Console/build.fsx
+++ b/Content/Console/build.fsx
@@ -102,7 +102,15 @@ Target.create "Clean" <| fun _ ->
         )
     |> Shell.cleanDirs
 
+    [
+        "paket-files/paket.restore.cached"
+    ]
+    |> Seq.iter Shell.rm
+
 Target.create "DotnetRestore" <| fun _ ->
+    Paket.restore(fun p ->
+        {p with ToolPath = __SOURCE_DIRECTORY__ </> ".paket" </> (if Environment.isWindows then "paket.exe" else "paket")})
+
     [sln ; toolsDir]
     |> Seq.map(fun dir -> fun () ->
         let args =

--- a/Content/Library/build.fsx
+++ b/Content/Library/build.fsx
@@ -101,7 +101,15 @@ Target.create "Clean" <| fun _ ->
         )
     |> Shell.cleanDirs
 
+    [
+        "paket-files/paket.restore.cached"
+    ]
+    |> Seq.iter Shell.rm
+
 Target.create "DotnetRestore" <| fun _ ->
+    Paket.restore(fun p ->
+        {p with ToolPath = __SOURCE_DIRECTORY__ </> ".paket" </> (if Environment.isWindows then "paket.exe" else "paket")})
+
     [sln ; toolsDir]
     |> Seq.map(fun dir -> fun () ->
         let args =


### PR DESCRIPTION
## Proposed Changes

This speeds up DotnetRestore target by clearing paket.restore.cached, which allows paket restore to really run and do all projects at once.  Otherwise dotnet restore would try to create a paket process per project, since they share resources paket has a lock file so they spin lock until they can run, causing slowness.

## Types of changes

What types of changes does your code introduce to MiniScaffold?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
