### PR TITLE
Make it so local builds work

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -192,4 +192,4 @@ Target.create "Release" ignore
   ==> "Release"
 
 
-Target.runOrDefaultWithArguments "IntegrationTests"
+Target.runOrDefaultWithArguments (if isCI then "IntegrationTests" else "DotnetPack")


### PR DESCRIPTION
## Proposed Changes

Local build does not work for me right now. Repro: 

```bash
git clone https://github.com/TheAngryByrd/MiniScaffold.git
cd MiniScaffold
./build.sh
```
The dependency graph looks like this

https://github.com/TheAngryByrd/MiniScaffold/blob/e6cdbec06c36fbcd6ef553d4757b2741a43f454d/build.fsx#L184-L192

but because `isCI` is false, FAKE reports the dependency graph as this: 

```
Shortened DependencyGraph for Target IntegrationTests:
<== IntegrationTests
```

This small change fixes the build locally for me.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)


