### PR TITLE
GitHub Actions for MiniScaffold itself

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        dotnet: [2.2.401, 3.0.100-preview9-014004]
+        # dotnet: [2.2.401, 3.0.100-preview9-014004]
+        dotnet: [2.2.401]
     runs-on: ${{ matrix.os }}
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,11 @@ jobs:
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/${{ matrix.dotnet }}/x64
+        CI: true
     - name: Build
       if: runner.os == 'Windows'
       run: ./build.cmd
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/${{ matrix.dotnet }}/x64
+        CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build master
+
+on: [push]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        dotnet: [2.2.401, 3.0.100-preview9-014004]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ matrix.dotnet }}
+    - name: Build
+      if: runner.os != 'Windows'
+      run: ./build.sh
+      env:
+        # Work around https://github.com/actions/setup-dotnet/issues/29
+        DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/${{ matrix.dotnet }}/x64
+    - name: Build
+      if: runner.os == 'Windows'
+      run: ./build.cmd
+      env:
+        # Work around https://github.com/actions/setup-dotnet/issues/29
+        DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/${{ matrix.dotnet }}/x64

--- a/build.fsx
+++ b/build.fsx
@@ -192,4 +192,4 @@ Target.create "Release" ignore
   ==> "Release"
 
 
-Target.runOrDefaultWithArguments "IntegrationTests"
+Target.runOrDefaultWithArguments (if isCI then "IntegrationTests" else "DotnetPack")


### PR DESCRIPTION
## Proposed Changes

This builds MiniScaffold itself with GitHub Actions on Ubuntu, MacOS and Windows. 
It's the first step of #143. 
[Test Run](https://github.com/rojepp/MiniScaffold/commit/56a680a8e10e47d0086b8b71250284c587babe26/checks)
The next step is to have the templates do the same. 
GitHub actions is in beta and is scheduled to be released Nov 13. One can apply for the beta [here](https://github.com/features/actions). There is no waiting list any longer according to Nat Friedman.

There is a workaround in the workflow right now because of a bug in [setup-dotnet](https://github.com/actions/setup-dotnet/). [PR here](https://github.com/actions/setup-dotnet/pull/34). Once the bug is fixed, the `DOTNET_ROOT` line below can be removed in two places.  

```yaml
      env:
        # Work around https://github.com/actions/setup-dotnet/issues/29
        DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/${{ matrix.dotnet }}/x64
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This PR includes the changes in #144, so if those changes aren't acceptable I'll have some rebasing to do. 😅
