### PR TITLE
Set build.sh permissions in github workflow

### DIFF
--- a/Content/Console/.github/workflows/build.yml
+++ b/Content/Console/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        dotnet: [2.2.402]
+        dotnet: [3.1.100]
     runs-on: ${{ matrix.os }}
     
     steps:

--- a/Content/Console/.github/workflows/build.yml
+++ b/Content/Console/.github/workflows/build.yml
@@ -19,7 +19,9 @@ jobs:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Build
       if: runner.os != 'Windows'
-      run: ./build.sh
+      run: |
+        chmod +x ./build.sh
+        ./build.sh
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/${{ matrix.dotnet }}/x64

--- a/Content/Library/.github/build.yml
+++ b/Content/Library/.github/build.yml
@@ -8,8 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        # dotnet: [2.2.402, 3.0.100-preview9-014004]
-        dotnet: [2.2.402]
+        dotnet: [3.1.100]
     runs-on: ${{ matrix.os }}
     
     steps:

--- a/Content/Library/.github/build.yml
+++ b/Content/Library/.github/build.yml
@@ -20,7 +20,9 @@ jobs:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Build
       if: runner.os != 'Windows'
-      run: ./build.sh
+      run: |
+        chmod +x ./build.sh
+        ./build.sh
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/${{ matrix.dotnet }}/x64

--- a/Content/Library/.github/workflows/build.yml
+++ b/Content/Library/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        dotnet: [2.2.402]
+        dotnet: [3.1.100]
     runs-on: ${{ matrix.os }}
     
     steps:

--- a/Content/Library/.github/workflows/build.yml
+++ b/Content/Library/.github/workflows/build.yml
@@ -19,7 +19,9 @@ jobs:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Build
       if: runner.os != 'Windows'
-      run: ./build.sh
+      run: |
+        chmod +x ./build.sh
+        ./build.sh
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/${{ matrix.dotnet }}/x64


### PR DESCRIPTION
Setting the build.sh permissions in the github workflow fixes the Linux build problem when the script loses its attributes on Windows.

Initially I went down the wrong path playing with the travis.yml.  It specifies the build script but this is completely ignored: the github workflow takes charge.