### PR TITLE
Fix typo in README

### DIFF
--- a/Content/Console/README.md
+++ b/Content/Console/README.md
@@ -86,7 +86,7 @@ $ ./build.sh  <optional buildtarget>// on unix
 ```sh
 git add .
 git commit -m "Scaffold"
-git remote add origin origin https://github.com/user/MyCoolNewLib.git
+git remote add origin https://github.com/user/MyCoolNewApp.git
 git push -u origin master
 ```
 

--- a/Content/Library/README.md
+++ b/Content/Library/README.md
@@ -103,7 +103,7 @@ src/MyCoolNewLib/bin/
 ```sh
 git add .
 git commit -m "Scaffold"
-git remote add origin origin https://github.com/user/MyCoolNewLib.git
+git remote add origin https://github.com/user/MyCoolNewLib.git
 git push -u origin master
 ```
 


### PR DESCRIPTION
Example `git remote` command had `origin` listed twice so it was an invalid command. Also while I was at it, changed "MyCoolNewLib" sample name to "MyCoolNewApp" in the console-project version of the readme.
