### PR TITLE
Resolves #187

### DIFF
--- a/Content/Console/build.fsx
+++ b/Content/Console/build.fsx
@@ -479,7 +479,12 @@ let gitRelease _ =
 
     let releaseNotesGitCommitFormat = latestEntry.ToString()
 
-    Git.Staging.stageAll ""
+    Git.Staging.stageFile "" "CHANGELOG.md"
+        |> ignore
+
+    !! "src/**/AssemblyInfo.fs"
+        |> Seq.iter (Git.Staging.stageFile "" >> ignore)
+
     Git.Commit.exec "" (sprintf "Bump version to %s\n\n%s" latestEntry.NuGetVersion releaseNotesGitCommitFormat)
     Git.Branches.push ""
 

--- a/Content/Library/build.fsx
+++ b/Content/Library/build.fsx
@@ -525,7 +525,12 @@ let gitRelease _ =
 
     let releaseNotesGitCommitFormat = latestEntry.ToString()
 
-    Git.Staging.stageAll ""
+    Git.Staging.stageFile "" "CHANGELOG.md"
+        |> ignore
+
+    !! "src/**/AssemblyInfo.fs"
+        |> Seq.iter (Git.Staging.stageFile "" >> ignore)
+
     Git.Commit.exec "" (sprintf "Bump version to %s\n\n%s" latestEntry.NuGetVersion releaseNotesGitCommitFormat)
     Git.Branches.push ""
 

--- a/build.fsx
+++ b/build.fsx
@@ -379,7 +379,12 @@ let ``git release`` _ =
 
     let releaseNotesGitCommitFormat = latestEntry.ToString()
 
-    Git.Staging.stageAll ""
+    Git.Staging.stageFile "" "CHANGELOG.md"
+        |> ignore
+
+    !! "Content/**/AssemblyInfo.fs"
+        |> Seq.iter (Git.Staging.stageFile "" >> ignore)
+
     Git.Commit.exec "" (sprintf "Bump version to %s\n\n%s" latestEntry.NuGetVersion releaseNotesGitCommitFormat)
     Git.Branches.push ""
 


### PR DESCRIPTION
Git stage all can accidentally include unintended changes into a release commit. This change explicitly instructs Git to only stage the CHANGELOG and the AssemblyInfo.

Resolves #187

## Proposed Changes

In the build scripts Git stage all can accidentally include unintended changes into a release commit. This change explicitly instructs Git to only stage the CHANGELOG and the AssemblyInfo.

## Types of changes

What types of changes does your code introduce to MiniScaffold?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
