### PR TITLE
Code coverage will only include what we have the source code for

### DIFF
--- a/Content/Console/build.fsx
+++ b/Content/Console/build.fsx
@@ -385,6 +385,7 @@ let dotnetTest ctx =
                 sprintf "/p:AltCover=%b" (not disableCodeCoverage)
                 sprintf "/p:AltCoverThreshold=%d" coverageThresholdPercent
                 sprintf "/p:AltCoverAssemblyExcludeFilter=%s" excludeCoverage
+                "/p:AltCoverLocalSource=true"
             ]
         { c with
             Configuration = configuration (ctx.Context.AllExecutingTargets)

--- a/Content/Library/build.fsx
+++ b/Content/Library/build.fsx
@@ -436,6 +436,7 @@ let dotnetTest ctx =
             sprintf "/p:AltCover=%b" (not disableCodeCoverage)
             sprintf "/p:AltCoverThreshold=%d" coverageThresholdPercent
             sprintf "/p:AltCoverAssemblyExcludeFilter=%s" excludeCoverage
+            "/p:AltCoverLocalSource=true"
         ]
     DotNet.test(fun c ->
 


### PR DESCRIPTION
## Proposed Changes

Addresses #210 
Adds an extra parameter for AltCover to only calculate code coverage for code that we have the source files for

## Types of changes

What types of changes does your code introduce to MiniScaffold?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Already made these changes to [EFCore.FSharp](https://github.com/efcore/EFCore.FSharp/blob/master/build.fsx#L433) build file where it is no longer also trying to provide code coverage for all of EF Core
 