### PR TITLE
update default release branch name to `main`. Add `--releaseBranch` parameter to allow overriding this.

### DIFF
--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -32,7 +32,12 @@
                     "description": "Creates a template for console projects"
                 }
             ]
-        }
+        },
+	"releaseBranch": {
+	    "type": "parameter",
+	    "replaces": "MyReleaseBranch",
+	    "defaultValue": "main"
+	}
     },
     "sources": [
         {

--- a/Content/Console/build.fsx
+++ b/Content/Console/build.fsx
@@ -76,7 +76,7 @@ let gitRepoName = "MyLib.1"
 
 let gitHubRepoUrl = sprintf "https://github.com/%s/%s" gitOwner gitRepoName
 
-let releaseBranch = "master"
+let releaseBranch = "MyReleaseBranch"
 
 let tagFromVersionNumber versionNumber = sprintf "v%s" versionNumber
 

--- a/Content/Library/build.fsx
+++ b/Content/Library/build.fsx
@@ -76,7 +76,7 @@ let gitRepoName = "MyLib.1"
 
 let gitHubRepoUrl = sprintf "https://github.com/%s/%s" gitOwner gitRepoName
 
-let releaseBranch = "master"
+let releaseBranch = "MyReleaseBranch"
 
 let tagFromVersionNumber versionNumber = sprintf "v%s" versionNumber
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ dotnet new mini-scaffold -n MyCoolNewLib --githubUsername MyGithubUsername
 dotnet new mini-scaffold -n MyCoolNewApp --githubUsername MyGithubUsername -ou console
 ```
 
+The scaffold defaults to using the `main` branch for releases. If you release from a different branch, you can use the `--releaseBranch <branch name>` parameter to use your release branch instead of the default.
+
 ---
 
 ## Builds

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,6 +7,7 @@ group Build
     source https://www.nuget.org/api/v2
     storage: none
     nuget Expecto
+    nuget FSharp.Core ~> 5.0
     nuget YoloDev.Expecto.TestSdk
     nuget Microsoft.NET.Test.Sdk 15.7.2
     nuget Fake.IO.FileSystem 5.20.4-alpha.1642

--- a/paket.lock
+++ b/paket.lock
@@ -134,7 +134,7 @@ NUGET
     FSharp.Control.Reactive (4.4.2) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: || (>= net46) (>= netstandard2.0)
       System.Reactive (>= 4.4.1) - restriction: || (>= net46) (>= netstandard2.0)
-    FSharp.Core (4.7.2) - restriction: || (>= net461) (>= netstandard2.0)
+    FSharp.Core (5.0.1)
     Microsoft.Build (16.5) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 16.5) - restriction: || (>= net472) (>= netcoreapp2.1)
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
@@ -165,7 +165,6 @@ NUGET
       System.Resources.Extensions (>= 4.6) - restriction: >= netstandard2.0
       System.Resources.Writer (>= 4.0) - restriction: && (< net472) (>= netstandard2.0)
       System.Threading.Tasks.Dataflow (>= 4.9) - restriction: >= netstandard2.0
-    Microsoft.Build.Tasks.Git (1.0) - restriction: >= netstandard2.0
     Microsoft.Build.Utilities.Core (16.5) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 16.5) - restriction: >= netstandard2.0
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
@@ -182,10 +181,6 @@ NUGET
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: >= uap10.0
     Microsoft.NETCore.Platforms (3.1) - restriction: || (&& (>= monoandroid) (>= netcoreapp2.1)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1)) (&& (>= monotouch) (>= netcoreapp2.1)) (&& (>= net461) (>= netcoreapp2.1)) (>= netcoreapp2.0) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     Microsoft.NETCore.Targets (3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    Microsoft.SourceLink.Common (1.0) - restriction: >= netstandard2.0
-    Microsoft.SourceLink.GitHub (1.0) - restriction: >= netstandard2.0
-      Microsoft.Build.Tasks.Git (>= 1.0)
-      Microsoft.SourceLink.Common (>= 1.0)
     Microsoft.TestPlatform.ObjectModel (16.6.1) - restriction: || (&& (>= netcoreapp1.0) (>= uap10.0)) (>= netcoreapp2.1)
       NuGet.Frameworks (>= 5.0) - restriction: || (>= net451) (>= netstandard2.0)
     Microsoft.TestPlatform.TestHost (16.6.1) - restriction: >= netcoreapp1.0
@@ -210,7 +205,6 @@ NUGET
       Microsoft.Build.Framework (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Tasks.Core (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Utilities.Core (>= 16.4) - restriction: >= netstandard2.0
-      Microsoft.SourceLink.GitHub (>= 1.0) - restriction: >= netstandard2.0
     Newtonsoft.Json (12.0.3) - restriction: || (>= netstandard2.0) (>= uap10.0)
     NuGet.Common (5.6) - restriction: >= netstandard2.0
       NuGet.Frameworks (>= 5.6) - restriction: >= netstandard2.0

--- a/tests/MiniScaffold.Tests/Tests.fs
+++ b/tests/MiniScaffold.Tests/Tests.fs
@@ -256,6 +256,25 @@ module Tests =
                     Assert.``CHANGELOG does not contain Unreleased section``
                     ]
 
+                // Try to run a release on an alternate release branch name.
+                "-n AlternateReleaseBranch --githubUsername TestAccount --releaseBranch alternateBranch", [
+                    Effect.``setup for branch tests`` "alternateBranch"
+                    Effect.``disable pushing in gitRelease function``
+                    Effect.``change githubRelease function to only run release checks``
+                    Effect.``disable publishToNuget function`` // Simulates success, since it would fail due to NUGET_API being unset
+                    Assert.``project can build target`` "Release"
+                ]
+
+                // This should fail since the release branch specified in the build script doesn't match the
+                // branch from which the script is executed.
+                "-n ReleaseBranchMissingFailure --githubUsername TestAccount --releaseBranch notExist", [
+                    Effect.``setup for branch tests`` "anotherBranch"
+                    Effect.``disable pushing in gitRelease function``
+                    Effect.``change githubRelease function to only run release checks``
+                    Effect.``disable publishToNuget function`` // Simulates success, since it would fail due to NUGET_API being unset
+                    Assert.``build target with failure expected`` "Release"
+                ]
+
             ] |> Seq.map(fun (args, additionalAsserts) -> testCase args <| fun _ ->
                 use d = Disposables.DisposableDirectory.Create()
                 copyGlobalJson d.DirectoryInfo


### PR DESCRIPTION
## Proposed Changes

The [default branch name for new GitHub repositories is now `main`](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/). This diff changes the default release branch name for the scaffold to `main`, to align with that, but also adds a `--releaseBranch` configuration switch, to allow overriding that during initial scaffold setup (for example, if you're bootstrapping the scaffold into an existing repository).

## Types of changes

What types of changes does your code introduce to MiniScaffold?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

Build dependencies were changed to target F# 5.0, so that string interpolation can be used. This isn't critical, so it can be backed out if necessary.