### PR TITLE
Adjust Dockerfiles to copy install-dotnets.sh correctly on new versions of Docker.

### DIFF
--- a/Content/Console/.devcontainer/Dockerfile
+++ b/Content/Console/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ ENV \
     DOTNET_INSTALL_DIR=/usr/share/dotnet/ \
     DOTNET_ROOT=/usr/share/dotnet/
 
-COPY ./.devcontainer/install-dotnets.sh global.json* .
+COPY ./.devcontainer/install-dotnets.sh global.json* ./
 
 RUN /bin/bash install-dotnets.sh
 


### PR DESCRIPTION
I faced an issue using the devcontainer locally, and turned out to be resolved by this little change:
https://stackoverflow.com/questions/53650492/when-using-copy-with-more-than-one-source-file-the-destination-must-be-a-direct

This adjusts the Dockerfiles to have a trailing `/` on the end of the
`COPY ./.devcontainer/install-dotnets.sh global.json* .`
lines.

So far the PR just has a commit on the `Console` project, because I made the change via GitHub UI. Shortly I'll add a second commit for the library project.