### PR TITLE
Coverage report tweaks

### DIFF
--- a/Content/Library/.github/workflows/build.yml
+++ b/Content/Library/.github/workflows/build.yml
@@ -31,8 +31,10 @@ jobs:
           ./build.sh
         env:
           CI: true
+          ENABLE_COVERAGE: true
       - name: Build via Windows
         if: runner.os == 'Windows'
         run: ./build.cmd
         env:
           CI: true
+          ENABLE_COVERAGE: true

--- a/Content/Library/.github/workflows/publish.yml
+++ b/Content/Library/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FAKE_DETAILED_ERRORS: true
-          DISABLE_COVERAGE: true # AltCover doesn't work with Release builds, reports lower coverage than actual
+          ENABLE_COVERAGE: false # AltCover doesn't work with Release builds, reports lower coverage than actual
         run: |
           chmod +x ./build.sh
           ./build.sh Publish

--- a/Content/Library/README.md
+++ b/Content/Library/README.md
@@ -36,8 +36,8 @@ or
 
 - `CONFIGURATION` will set the [configuration](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-build?tabs=netcore2x#options) of the dotnet commands.  If not set, it will default to Release.
   - `CONFIGURATION=Debug ./build.sh` will result in `-c` additions to commands such as in `dotnet build -c Debug`
-- `DISABLE_COVERAGE` Will disable running code coverage metrics.  AltCover can have [severe performance degradation](https://github.com/SteveGilham/altcover/issues/57) so it's worth disabling when looking to do a quicker feedback loop.
-  - `DISABLE_COVERAGE=1 ./build.sh`
+- `ENABLE_COVERAGE` Will enable running code coverage metrics.  AltCover can have [severe performance degradation](https://github.com/SteveGilham/altcover/issues/57) so code coverage evaluation are disabled by default to speed up the feedback loop.
+  - `ENABLE_COVERAGE=1 ./build.sh` will enable code coverage evaluation
 
 
 ---

--- a/Content/Library/README.md
+++ b/Content/Library/README.md
@@ -74,6 +74,7 @@ src/MyLib.1/bin/
 - `FSharpAnalyzers` - Runs [BinaryDefense.FSharp.Analyzers](https://github.com/BinaryDefense/BinaryDefense.FSharp.Analyzers).
 - `DotnetTest` - Runs [dotnet test](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=netcore21) on the [solution file](https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/solution-dot-sln-file?view=vs-2019).
 - `GenerateCoverageReport` - Code coverage is run during `DotnetTest` and this generates a report via [ReportGenerator](https://github.com/danielpalme/ReportGenerator).
+- `ShowCoverageReport` - Shows the report generated in `GenerateCoverageReport`.
 - `WatchTests` - Runs [dotnet watch](https://docs.microsoft.com/en-us/aspnet/core/tutorials/dotnet-watch?view=aspnetcore-3.0) with the test projects. Useful for rapid feedback loops.
 - `GenerateAssemblyInfo` - Generates [AssemblyInfo](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualbasic.applicationservices.assemblyinfo?view=netframework-4.8) for libraries.
 - `DotnetPack` - Runs [dotnet pack](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack). This includes running [Source Link](https://github.com/dotnet/sourcelink).

--- a/Content/Library/build/build.fs
+++ b/Content/Library/build/build.fs
@@ -403,12 +403,16 @@ let dotnetTest ctx =
         |> Seq.map IO.Path.GetFileNameWithoutExtension
         |> String.concat "|"
 
+    let isGenerateCoverageReport = ctx.Context.TryFindTarget("GenerateCoverageReport").IsSome
+
     let args = [
         "--no-build"
-        sprintf "/p:AltCover=%b" (not disableCodeCoverage)
-        sprintf "/p:AltCoverThreshold=%d" coverageThresholdPercent
-        sprintf "/p:AltCoverAssemblyExcludeFilter=%s" excludeCoverage
-        "/p:AltCoverLocalSource=true"
+        if not disableCodeCoverage || isGenerateCoverageReport then
+            sprintf "/p:AltCover=true"
+            if not isGenerateCoverageReport then
+                sprintf "/p:AltCoverThreshold=%d" coverageThresholdPercent
+            sprintf "/p:AltCoverAssemblyExcludeFilter=%s" excludeCoverage
+            "/p:AltCoverLocalSource=true"
     ]
 
     DotNet.test
@@ -769,6 +773,9 @@ let initTargets () =
 
     "DotnetBuild"
     ==>! "WatchDocs"
+
+    "DotnetTest"
+    ==>! "GenerateCoverageReport"
 
     "UpdateChangelog"
     ==> "GenerateAssemblyInfo"

--- a/Content/Library/build/build.fs
+++ b/Content/Library/build/build.fs
@@ -131,7 +131,7 @@ let mutable changelogBackupFilename = ""
 
 let publishUrl = "https://www.nuget.org"
 
-let disableCodeCoverage = environVarAsBoolOrDefault "DISABLE_COVERAGE" false
+let enableCodeCoverage = environVarAsBoolOrDefault "ENABLE_COVERAGE" false
 
 let githubToken = Environment.environVarOrNone "GITHUB_TOKEN"
 
@@ -411,7 +411,7 @@ let dotnetTest ctx =
 
     let args = [
         "--no-build"
-        if not disableCodeCoverage || isGenerateCoverageReport then
+        if enableCodeCoverage || isGenerateCoverageReport then
             sprintf "/p:AltCover=true"
             if not isGenerateCoverageReport then
                 sprintf "/p:AltCoverThreshold=%d" coverageThresholdPercent


### PR DESCRIPTION
## Proposed Changes
This PR:
- Restores the GenerateCoverageReport dependency chain broken in #271
- Сloses #251
- Adds the handy ShowCoverageReport target  to the library template 


## Types of changes

What types of changes does your code introduce to MiniScaffold?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

Unclosed question on test coverage verification. It is not necessary to evaluate test coverage every time you run tests, and to speed up feedback, it is inconvenient to write the `cmd /c "set DISABLE_COVERAGE=1& build DotnetTest"` command on Windows, for example. I propose to change the logic and replacing the environment variable with ENABLE_COVERAGE. And local testing with test coverage is convenient to do with a new ShowCoverageReport target. What do you think?