### PR TITLE
Fix Changelog diff link on github releases

### DIFF
--- a/Content/Console/build/Changelog.fs
+++ b/Content/Console/build/Changelog.fs
@@ -47,7 +47,7 @@ let mkLinkReference (newVersion: SemVerInfo) (changelog: Changelog.Changelog) gi
             changelog.Entries
             |> List.skipWhile (fun entry ->
                 entry.SemVer.PreRelease.IsSome
-                && versionTuple entry.SemVer = versionTuple newVersion
+                || versionTuple entry.SemVer = versionTuple newVersion
             )
             |> List.tryHead
 

--- a/Content/Library/build/Changelog.fs
+++ b/Content/Library/build/Changelog.fs
@@ -46,7 +46,7 @@ let mkLinkReference (newVersion: SemVerInfo) (changelog: Changelog.Changelog) gi
             changelog.Entries
             |> List.skipWhile (fun entry ->
                 entry.SemVer.PreRelease.IsSome
-                && versionTuple entry.SemVer = versionTuple newVersion
+                || versionTuple entry.SemVer = versionTuple newVersion
             )
             |> List.tryHead
 

--- a/build/Changelog.fs
+++ b/build/Changelog.fs
@@ -46,7 +46,7 @@ let mkLinkReference (newVersion: SemVerInfo) (changelog: Changelog.Changelog) gi
             changelog.Entries
             |> List.skipWhile (fun entry ->
                 entry.SemVer.PreRelease.IsSome
-                && versionTuple entry.SemVer = versionTuple newVersion
+                || versionTuple entry.SemVer = versionTuple newVersion
             )
             |> List.tryHead
 


### PR DESCRIPTION
## Proposed Changes

When creating a `GitHub Release` on the `Publish` path, the changelog link compare generation was incorrectly generating a link to itself.

```
## [0.36.1] - 2023-10-21

[0.36.1]: https://github.com/TheAngryByrd/MiniScaffold/compare/v0.36.1...v0.36.1

### Changed
- [Adds devcontainer builds to CI](https://github.com/TheAngryByrd/MiniScaffold/pull/281) from @TheAngryByrd
```



## Types of changes

What types of changes does your code introduce to MiniScaffold?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
